### PR TITLE
Use Fill API to fetch versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,4 @@ build
 sources
 output
 
-test
-test2
-test3
+schema.graphql

--- a/graphql.config.yml
+++ b/graphql.config.yml
@@ -1,0 +1,2 @@
+schema: https://fill.papermc.io/graphql
+documents: src/main/java/dev.minidigger.apidiff/Main.java


### PR DESCRIPTION
Also change some things around how jars were fetched as there were some issues around parsing pre/rc versions as well as hopefully making it work just fine whenever the new versioning system gets implemented.

I don't love how I ended up parsing the response body, but I didn't feel like it was worth making 4-5 records for a single request to or make a TypeAdapter for it. If you feel like that's the better way then I can change it to that.