### PR TITLE
feat: add support for version >=26.1

### DIFF
--- a/src/main/java/dev.minidigger.apidiff/ApiDiffer.java
+++ b/src/main/java/dev.minidigger.apidiff/ApiDiffer.java
@@ -19,10 +19,10 @@ public class ApiDiffer {
     public final Map<String, ApiDiff> diffs = new LinkedHashMap<>();
 
     @SuppressWarnings("unchecked")
-    public ApiExport load(String version) {
-        return exports.computeIfAbsent(version, v -> {
+    public ApiExport load(VersionInfo version) {
+        return exports.computeIfAbsent(version.name(), v -> {
             try {
-                List<Map<String, Object>> input = gson.fromJson(Files.readString(Path.of("output/raw/paper-api-" + version + ".json")), ArrayList.class);
+                List<Map<String, Object>> input = gson.fromJson(Files.readString(Path.of("output/raw/paper-api-" + version.name() + ".json")), ArrayList.class);
                 ApiExport export = new ApiExport(version, new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>());
                 parse(input, export, null);
                 return export;
@@ -32,7 +32,7 @@ public class ApiDiffer {
         });
     }
 
-    public void diff(String versionA, String versionB, Path output) throws Exception {
+    public void diff(VersionInfo versionA, VersionInfo versionB, Path output) throws Exception {
         // read the two api exports
         ApiExport a = load(versionA);
         ApiExport b = load(versionB);
@@ -113,12 +113,12 @@ public class ApiDiffer {
                 membersRemoved.stream().collect(Collectors.groupingBy((m) -> m.parent().name())),
                 membersChanged.stream().collect(Collectors.groupingBy((m) -> m.parent().name()))
         );
-        diffs.put(versionA + "-" + versionB, diff);
+        diffs.put(versionA.name() + "-" + versionB.name(), diff);
 
         // poor mans type adapter
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("versionA", versionA);
-        result.put("versionB", versionB);
+        result.put("versionA", versionA.name());
+        result.put("versionB", versionB.name());
         result.put("packagesAdded", packagesAdded.stream().map(Package::name).toList());
         result.put("packagesRemoved", packagesRemoved.stream().map(Package::name).toList());
         result.put("packagesChanged", packagesChanged.stream().map(Package::name).toList());
@@ -131,7 +131,7 @@ public class ApiDiffer {
         Files.writeString(output, gson.toJson(result));
     }
 
-    public record ApiDiff(String versionA, String versionB,
+    public record ApiDiff(VersionInfo versionA, VersionInfo versionB,
                           List<Package> packagesAdded, List<Package> packagesRemoved, List<Package> packagesChanged,
                           List<Class> classesAdded, List<Class> classesRemoved, List<Class> classesChanged,
                           Map<String, List<Member>> membersAdded, Map<String, List<Member>> membersRemoved,
@@ -174,7 +174,7 @@ public class ApiDiffer {
         }
     }
 
-    public record ApiExport(String version, Map<String, Package> packages, Map<String, Class> classes,
+    public record ApiExport(VersionInfo version, Map<String, Package> packages, Map<String, Class> classes,
                             Map<String, Member> members) {
     }
 

--- a/src/main/java/dev.minidigger.apidiff/HtmlGenerator.java
+++ b/src/main/java/dev.minidigger.apidiff/HtmlGenerator.java
@@ -94,7 +94,7 @@ public class HtmlGenerator {
         }
     }
 
-    public void generateSince(List<String> versions, SinceReport sinceReport) throws IOException {
+    public void generateSince(List<VersionInfo> versions, SinceReport sinceReport) throws IOException {
         StringBuilder html = new StringBuilder("""
                 <html lang="en">
                 <head>
@@ -129,8 +129,8 @@ public class HtmlGenerator {
         Files.writeString(output.resolve("since.html"), html.toString());
     }
 
-    public void generateDiff(String versionA, String versionB) throws Exception {
-        ApiDiff diff = apiDiffer.diffs.get(versionA + "-" + versionB);
+    public void generateDiff(VersionInfo versionA, VersionInfo versionB) throws Exception {
+        ApiDiff diff = apiDiffer.diffs.get(versionA.name() + "-" + versionB.name());
         String html = """
                 <html lang="en">
                 <head>
@@ -162,8 +162,8 @@ public class HtmlGenerator {
                 </html>
                 """
                 .replace("{css}", css)
-                .replace("{versionA}", versionA)
-                .replace("{versionB}", versionB)
+                .replace("{versionA}", versionA.name())
+                .replace("{versionB}", versionB.name())
                 .replace("{packagesAdded}", list(diff.packagesAdded()))
                 .replace("{packagesRemoved}", list(diff.packagesRemoved()))
                 .replace("{packagesChanged}", list(diff.packagesChanged()))
@@ -174,10 +174,10 @@ public class HtmlGenerator {
                 .replace("{membersRemoved}", group(diff.membersRemoved(), versionA))
                 .replace("{membersChanged}", group(diff.membersChanged(), versionB));
 
-        Files.writeString(output.resolve("diff-" + versionA + "-" + versionB + ".html"), html);
+        Files.writeString(output.resolve("diff-" + versionA.name() + "-" + versionB.name() + ".html"), html);
     }
 
-    private String group(Map<String, List<Member>> input, String version) {
+    private String group(Map<String, List<Member>> input, VersionInfo version) {
         return input.keySet().stream().sorted()
                 .map((c) -> {
                     String link = apiDiffer.load(version).classes().get(c).link();

--- a/src/main/java/dev.minidigger.apidiff/Main.java
+++ b/src/main/java/dev.minidigger.apidiff/Main.java
@@ -32,6 +32,12 @@ public class Main {
                                 key
                             }
                             key
+                            builds(last: 1) {
+                                nodes {
+                                    number
+                                    channel
+                                }
+                            }
                          }
                      }
                  }
@@ -46,17 +52,17 @@ public class Main {
         ApiDiffer apiDiffer = new ApiDiffer();
         SourceFetcher sourceFetcher = new SourceFetcher();
 
-        List<String> versions = getVersions(main, sourceFetcher);
+        List<VersionInfo> versions = getVersions(main, sourceFetcher);
 
         SinceGenerator sinceGenerator = new SinceGenerator(versions, apiDiffer);
         HtmlGenerator htmlGenerator = new HtmlGenerator(apiDiffer);
         // generate api-export json
-        for (String version : versions) {
+        for (VersionInfo version : versions) {
             main.generateApiExport(version);
         }
 
         for (int i = 0; i < versions.size() - 1; i++) {
-            apiDiffer.diff(versions.get(i), versions.get(i + 1), Path.of("output/raw/paper-api-diff-" + versions.get(i) + "-" + versions.get(i + 1) + ".json"));
+            apiDiffer.diff(versions.get(i), versions.get(i + 1), Path.of("output/raw/paper-api-diff-" + versions.get(i).name() + "-" + versions.get(i + 1).name() + ".json"));
             htmlGenerator.generateDiff(versions.get(i), versions.get(i + 1));
         }
 
@@ -69,8 +75,8 @@ public class Main {
         htmlGenerator.generateIndex();
     }
 
-    private static @NonNull List<String> getVersions(Main main, SourceFetcher sourceFetcher) throws IOException, InterruptedException {
-        List<String> versions;
+    private static @NonNull List<VersionInfo> getVersions(Main main, SourceFetcher sourceFetcher) throws IOException, InterruptedException {
+        List<VersionInfo> versions;
 
         boolean automatic = true;
         if (automatic) {
@@ -81,7 +87,7 @@ public class Main {
 
                 versionFamily.getValue().removeIf(version -> {
                     try {
-                        return version.contains("pre") || version.contains("rc") || !sourceFetcher.fetchSourcesJar(family, version);
+                        return version.name().contains("pre") || version.name().contains("rc") || !sourceFetcher.fetchSourcesJar(family, version);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
@@ -96,10 +102,11 @@ public class Main {
                     .flatMap(Collection::stream)
                     .toList();
         } else {
-            versions = List.of("1.21.3", "1.21.4");
+            // TODO: automatically fetch build number and channel
+            versions = List.of(new VersionInfo("1.21.3", 0, "STABLE"), new VersionInfo("1.21.4", 0, "STABLE"));
             versions.forEach(version -> {
                 try {
-                    sourceFetcher.fetchSourcesJar(version, version);
+                    sourceFetcher.fetchSourcesJar(version.name(), version);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -108,7 +115,7 @@ public class Main {
         return versions;
     }
 
-    public @NonNull Map<String, List<String>> fetchVersions() throws IOException, InterruptedException {
+    public @NonNull Map<String, List<VersionInfo>> fetchVersions() throws IOException, InterruptedException {
         try (var client = HttpClient.newHttpClient()) {
             var request = HttpRequest.newBuilder()
                     .uri(API_URL)
@@ -138,19 +145,23 @@ public class Main {
                             v -> v.getAsJsonObject("family").get("key").getAsString(),
                             LinkedHashMap::new,
                             Collectors.mapping(
-                                    v -> v.get("key").getAsString(),
+                                    v -> {
+                                        var key = v.get("key").getAsString();
+                                        var build = v.getAsJsonObject("builds").getAsJsonArray("nodes").get(0).getAsJsonObject();
+                                        return new VersionInfo(key, build.get("number").getAsInt(), build.get("channel").getAsString());
+                                    },
                                     Collectors.toCollection(ArrayList::new)
                             )
                     ));
         }
     }
 
-    public void generateApiExport(String version) {
+    public void generateApiExport(VersionInfo version) {
         // TODO add hash check to prevent rerunning
         String packages = "com.destroystokyo.paper:org.bukkit:org.spigotmc";
-        if (Files.isDirectory(Path.of("sources/paper-api-" + version + "/io"))) {
+        if (Files.isDirectory(Path.of("sources/paper-api-" + version.name() + "/io"))) {
             packages += ":io.papermc.paper";
         }
-        execute("--ignore-source-errors", "-public", "-quiet", "-doclet", "dev.minidigger.apidiff.ApiExportDoclet", "--output-file", "output/raw/paper-api-" + version + ".json", "--mc-version", version, "-sourcepath", "sources/paper-api-" + version, "-subpackages", packages);
+        execute("--ignore-source-errors", "-public", "-quiet", "-doclet", "dev.minidigger.apidiff.ApiExportDoclet", "--output-file", "output/raw/paper-api-" + version.name() + ".json", "--mc-version", version.name(), "-sourcepath", "sources/paper-api-" + version.name(), "-subpackages", packages);
     }
 }

--- a/src/main/java/dev.minidigger.apidiff/SinceGenerator.java
+++ b/src/main/java/dev.minidigger.apidiff/SinceGenerator.java
@@ -12,10 +12,10 @@ import java.util.Map;
 
 public class SinceGenerator {
 
-    private final List<String> versions;
+    private final List<VersionInfo> versions;
     private final ApiDiffer apiDiffer;
 
-    public SinceGenerator(List<String> versions, ApiDiffer apiDiffer) {
+    public SinceGenerator(List<VersionInfo> versions, ApiDiffer apiDiffer) {
         this.versions = versions;
         this.apiDiffer = apiDiffer;
     }
@@ -53,39 +53,39 @@ public class SinceGenerator {
     }
 
     private String packetSince(ApiDiffer.Package aPackage) {
-        for (String version : versions) {
+        for (VersionInfo version : versions) {
             ApiDiffer.ApiExport export = apiDiffer.load(version);
             if (export.packages().containsKey(aPackage.name())) {
                 if (version.equals(versions.getFirst())) {
                     return "basically forever";
                 }
-                return version;
+                return version.name();
             }
         }
         return "forever";
     }
 
     private String classSince(ApiDiffer.Class aClass) {
-        for (String version : versions) {
+        for (VersionInfo version : versions) {
             ApiDiffer.ApiExport export = apiDiffer.load(version);
             if (export.classes().containsKey(aClass.name())) {
                 if (version.equals(versions.getFirst())) {
                     return "basically forever";
                 }
-                return version;
+                return version.name();
             }
         }
         return "forever";
     }
 
     private String memberSince(ApiDiffer.Member member) {
-        for (String version : versions) {
+        for (VersionInfo version : versions) {
             ApiDiffer.ApiExport export = apiDiffer.load(version);
             if (export.members().containsKey(member.name())) {
                 if (version.equals(versions.getFirst())) {
                     return "basically forever";
                 }
-                return version;
+                return version.name();
             }
         }
         return "forever";

--- a/src/main/java/dev.minidigger.apidiff/SourceFetcher.java
+++ b/src/main/java/dev.minidigger.apidiff/SourceFetcher.java
@@ -19,25 +19,31 @@ import java.util.zip.ZipInputStream;
 
 public class SourceFetcher {
 
-    public boolean fetchSourcesJar(String family, String version) throws Exception {
-        // TODO add hash check to prevent redownloading
-        System.out.println("Fetching sources for " + version);
+    private boolean isVersionNew(String family) {
         var parts = family.split("\\.");
         int major = Integer.parseInt(parts[0]);
-        int minor = Integer.parseInt(parts[1]);
-        String group = "io/papermc";
-        // hopefully this doesn't break with new versioning system
-        if (major < 26 && minor < 17)
-            group = "com/destroystokyo";
+        return major >= 26;
+    }
 
-        String metadataUrl = "https://repo.papermc.io/repository/maven-public/" + group + "/paper/paper-api/" + version.replace(".0", ".") + "-R0.1-SNAPSHOT/maven-metadata.xml";
-        String snapshotVersion = getLatestSnapshotVersion(metadataUrl);
-        if (snapshotVersion == null) {
-            System.err.println("Could not find snapshot version for " + version);
-            return false;
+    public boolean fetchSourcesJar(String family, VersionInfo version) throws Exception {
+        // TODO add hash check to prevent redownloading
+        System.out.println("Fetching sources for " + version.name());
+
+        // Versions >=26.1 do not have metadata xml files
+        String sourcesUrl;
+        if (!isVersionNew(family)) {
+            String metadataUrl = version.metadataUrl(family);
+            String snapshotVersion = getLatestSnapshotVersion(metadataUrl);
+            if (snapshotVersion == null) {
+                System.err.println("Could not find snapshot version for " + version.name());
+                return false;
+            }
+            sourcesUrl = version.sourcesUrl(family, snapshotVersion);
+        } else {
+            sourcesUrl = version.sourcesUrl(family, "");
         }
-        String sourcesUrl = "https://repo.papermc.io/repository/maven-public/" + group + "/paper/paper-api/" + version.replace(".0", ".") + "-R0.1-SNAPSHOT/paper-api-" + snapshotVersion + "-sources.jar";
-        downloadAndExtractSourcesToDisk(sourcesUrl, Path.of("sources/paper-api-" + version));
+
+        downloadAndExtractSourcesToDisk(sourcesUrl, Path.of("sources/paper-api-" + version.name()));
         return true;
     }
 

--- a/src/main/java/dev.minidigger.apidiff/VersionInfo.java
+++ b/src/main/java/dev.minidigger.apidiff/VersionInfo.java
@@ -1,0 +1,48 @@
+package dev.minidigger.apidiff;
+
+public record VersionInfo(String name, int build, String channel) {
+    private String channelSuffix() {
+        return switch(channel) {
+            case "ALPHA" -> "-alpha";
+            case "BETA" -> "-beta";
+            default -> "";
+        };
+    }
+
+    public String metadataUrl(String family) {
+        var parts = family.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        int minor = Integer.parseInt(parts[1]);
+        if (major >= 26) {
+            throw new RuntimeException("Versions >=26.1 do not have maven metadata");
+        }
+        String group = "io/papermc";
+        if (minor < 17) {
+            group = "com/destroystokyo";
+        }
+
+        return "https://repo.papermc.io/repository/maven-public/" + group + "/paper/paper-api/" + name.replace(".0", ".") + "-R0.1-SNAPSHOT/maven-metadata.xml";
+    }
+
+    public String sourcesUrl(String family, String snapshotVersion) {
+        var parts = family.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        int minor = Integer.parseInt(parts[1]);
+        String group = "io/papermc";
+        if (major < 26 && minor < 17) {
+            group = "com/destroystokyo";
+        }
+
+        String fullName = name.replace(".0", ".");
+        String sourcesName;
+        if (major < 26) {
+            fullName += "-R0.1-SNAPSHOT";
+            sourcesName = snapshotVersion;
+        } else {
+            fullName += ".build." + build + channelSuffix();
+            sourcesName = fullName;
+        }
+
+        return "https://repo.papermc.io/repository/maven-public/" + group + "/paper/paper-api/" + fullName + "/paper-api-" + sourcesName + "-sources.jar";
+    }
+}


### PR DESCRIPTION
Not sure if this is the best way to go about doing this, but I now fetch the last build number and its channel with GraphQL and use a VersionInfo record instead of a String to represent a version.
Additionally it seems there is no maven-metadata.xml anymore for newer versions, so I am not fetching that for those versions.

When manually specifying versions >=26.1 you must manually specify build number and channel (build number and channel are ignored for versions <26.1).